### PR TITLE
Add support for option, cookie and stats tags in backend instances

### DIFF
--- a/haproxy/templates/haproxy.jinja
+++ b/haproxy/templates/haproxy.jinja
@@ -83,6 +83,23 @@ frontend {{ frontend[1].name }}
 {%- for backend in salt['pillar.get']('haproxy:backends', {}).iteritems() %}
 backend {{ backend[1].name }}
     balance {{ backend[1].balance }}
+    {%- if 'options' in backend[1] %}
+    {%- for option in backend[1].options %}
+    option {{ option }}
+    {%- endfor %}
+    {%- endif %}
+    {%- if 'cookie' in backend[1] %}
+    cookie {{ backend[1].cookie }}
+    {%- endif %}
+    {%- if 'stats' in backend[1] %}
+    {%- for option, value in backend[1].stats.iteritems() %}
+    {%- if option == 'enable' and value %}
+    stats enable
+    {%- else %}
+    stats {{ option }} {{ value }}
+    {%- endif %}
+    {%- endfor %}
+    {%- endif %}
     {%- if 'servers' in backend[1] %}
     {%- for server in backend[1].servers.iteritems() %}
     server {{ server[1].name }} {{ server[1].host }}:{{ server[1].port }} {{ server[1].check }}{% endfor %}

--- a/pillar.example
+++ b/pillar.example
@@ -73,11 +73,23 @@ haproxy:
         server1:
           name: server1-its-name
           host: 192.168.1.213
+          port: 80
           check: check
     backend2:
       name: static
       balance: roundrobin
       redirect: scheme https if !{ ssl_fc }
+      options:
+        - http-server-close
+        - httpclose
+        - forwardfor    except 127.0.0.0/8
+        - httplog
+      cookie: "pm insert indirect"
+      stats:
+        enable: True
+        uri: /url/to/stats
+        realm: LoadBalancer
+        auth: "user:password"
       servers:
         server1:
           name: some-server


### PR DESCRIPTION
Just some options i needed to add in the backend instances.

It renders like:
```
backend www
    balance roundrobin
    option http-server-close
    option httpclose
    option forwardfor    except 127.0.0.0/8
    option httplog
    cookie pm insert indirect
    stats enable
    stats realm LoadBalancer
    stats uri /url/to/stats
    stats auth user:password
    server server1-its-name 192.168.1.213:80 check
```