### PR TITLE
Minor improvements

### DIFF
--- a/haproxy/init.sls
+++ b/haproxy/init.sls
@@ -3,6 +3,11 @@
 # Meta-state to fully setup haproxy on debian. (or any other distro that has haproxy in their repo)
 
 include:
+{% if salt['pillar.get']('haproxy:include') %}
+{% for item in salt['pillar.get']('haproxy:include') %}
+  - {{ item }}
+{% endfor %}
+{% endif %}
   - haproxy.install
   - haproxy.service
   - haproxy.config

--- a/haproxy/install.sls
+++ b/haproxy/install.sls
@@ -12,3 +12,9 @@ haproxy_ppa_repo:
 haproxy.install:
   pkg.installed:
     - name: haproxy
+{% if salt['pillar.get']('haproxy:require') %}
+    - require:
+{% for item in salt['pillar.get']('haproxy:require') %}
+      - {{ item }}
+{% endfor %}
+{% endif %}

--- a/haproxy/service.sls
+++ b/haproxy/service.sls
@@ -7,11 +7,13 @@ haproxy.service:
       - pkg: haproxy
     - watch:
       - file: haproxy.config
-  file.managed:
+  file.replace:
     - name: /etc/default/haproxy
-#TODO: Add switch to turn the service on and off based on pillar configuration.
-    - source: salt://haproxy/files/haproxy-init-enable
-    - create: True
-    - user: "root"
-    - group: "root"
-    - mode: "0644"
+{% if salt['pillar.get']('haproxy:enabled', True) %}
+    - pattern: ENABLED=0$
+    - repl: ENABLED=1
+{% else %}
+    - pattern: ENABLED=1$
+    - repl: ENABLED=0
+{% endif %}
+    - show_changes: True

--- a/haproxy/service.sls
+++ b/haproxy/service.sls
@@ -1,12 +1,19 @@
 haproxy.service:
+{% if salt['pillar.get']('haproxy:enable', True) %}
   service.running:
     - name: haproxy
     - enable: True
     - reload: True
     - require:
       - pkg: haproxy
+        file: haproxy.service
     - watch:
       - file: haproxy.config
+{% else %}
+  service.dead:
+    - name: haproxy
+    - enable: False
+{% endif %}
   file.replace:
     - name: /etc/default/haproxy
 {% if salt['pillar.get']('haproxy:enabled', True) %}

--- a/haproxy/templates/haproxy.jinja
+++ b/haproxy/templates/haproxy.jinja
@@ -5,6 +5,7 @@
 # This file is managed by Salt.
 # Any changes will be overwritten.
 
+
 #------------------
 # Global settings
 #------------------
@@ -15,14 +16,15 @@ global
     group {{ salt['pillar.get']('haproxy:global:group', 'haproxy') }}
 {%- if salt['pillar.get']('haproxy:global:chroot:enable', 'no') == True %}
     chroot  {{ salt['pillar.get']('haproxy:global:chroot:path', '/tmp') }}
-{% endif %}
+{%- endif %}
 {%- if salt['pillar.get']('haproxy:global:daemon', 'no') == True %}
     daemon
-{% endif %}
-{%- if salt['pillar.get']('haproxy:global:stats:enable', 'no') == True %}
+{%- endif %}
+{% if salt['pillar.get']('haproxy:global:stats:enable', 'no') == True %}
     # Stats support is currently limited to socket mode
     stats socket {{ salt['pillar.get']('haproxy:global:stats:socketpath', '/tmp/ha_stats.sock') }}
-{% endif %}
+{%- endif %}
+
 
 #------------------
 # common defaults that all the 'listen' and 'backend' sections will
@@ -47,13 +49,14 @@ defaults
   {%- for errorfile in salt['pillar.get']('haproxy:defaults:errorfiles').iteritems() %}
     errorfile {{ errorfile[0] }} {{ errorfile[1] }}
   {%- endfor %}
-{% endif %}
+{%- endif %}
+{%- if 'listens' in salt['pillar.get']('haproxy', {}) %}
+
 
 #------------------
 # listen instances
 #------------------
-{%- if 'listens' in salt['pillar.get']('haproxy', {}) %}
-  {%- for listener in salt['pillar.get']('haproxy:listens', {}).iteritems() %}
+{%- for listener in salt['pillar.get']('haproxy:listens', {}).iteritems() %}
 listen {{ listener[1].get('name', listener[0]) }}
     {%- if 'bind' in listener[1] %}
       {%- if listener[1].bind[1] is defined and listener[1].bind[1]|length > 1 %}
@@ -121,14 +124,14 @@ listen {{ listener[1].get('name', listener[0]) }}
       {%- endfor %}
     {% endif %}
   {%- endfor %}
-{% endif %}
+{%- endif %}
+{%- if 'frontends' in salt['pillar.get']('haproxy', {}) %}
 
 
 #------------------
 # frontend instances
 #------------------
-{%- if 'frontends' in salt['pillar.get']('haproxy', {}) %}
-  {%- for frontend in salt['pillar.get']('haproxy:frontends', {}).iteritems() %}
+{%- for frontend in salt['pillar.get']('haproxy:frontends', {}).iteritems() %}
 frontend {{ frontend[1].get('name', frontend[0]) }}
     {%- if 'bind' in frontend[1] %}
       {%- if frontend[1].bind[1] is defined and frontend[1].bind[1]|length > 1 %}
@@ -163,15 +166,16 @@ frontend {{ frontend[1].get('name', frontend[0]) }}
       {%- for use_backend in frontend[1].use_backends %}
     use_backend {{ use_backend }}
       {%- endfor %}
-    {% endif %}
+    {%- endif %}
   {%- endfor %}
-{% endif %}
+{%- endif %}
+{%- if 'backends' in salt['pillar.get']('haproxy', {}) %}
+
 
 #------------------
 # backend instances
 #------------------
-{%- if 'backends' in salt['pillar.get']('haproxy', {}) %}
-  {%- for backend in salt['pillar.get']('haproxy:backends', {}).iteritems() %}
+{%- for backend in salt['pillar.get']('haproxy:backends', {}).iteritems() %}
 backend {{ backend[1].get('name',backend[0]) }}
     {%- if 'redirects' in backend[1] %}
       {%- for redirect in backend[1].redirects %}
@@ -180,7 +184,7 @@ backend {{ backend[1].get('name',backend[0]) }}
     {% endif %}
     {%- if 'balance' in backend[1] %}
     balance {{ backend[1].balance }}
-    {% endif %}
+    {%- endif %}
     {%- if 'options' in backend[1] %}
       {%- for option in backend[1].options %}
     option {{ option }}
@@ -200,11 +204,11 @@ backend {{ backend[1].get('name',backend[0]) }}
     {% endif %}
     {%- if 'defaultserver' in backend[1] %}
     default-server {%- for option, value in backend[1].defaultserver.iteritems() %} {{ ' '.join((option, value|string, '')) }} {%- endfor %}
-    {% endif %}
+    {%- endif %}
     {%- if 'servers' in backend[1] %}
       {%- for server in backend[1].servers.iteritems() %}
     server {{ server[1].get('name',server[0]) }} {{ server[1].host }}:{{ server[1].port }} {{ server[1].check }}
       {%- endfor %}
     {% endif %}
   {%- endfor %}
-{% endif %}
+{%- endif %}

--- a/haproxy/templates/haproxy.jinja
+++ b/haproxy/templates/haproxy.jinja
@@ -5,7 +5,6 @@
 # This file is managed by Salt.
 # Any changes will be overwritten.
 
-
 #------------------
 # Global settings
 #------------------
@@ -49,7 +48,6 @@ defaults
     errorfile {{ errorfile[0] }} {{ errorfile[1] }}
   {%- endfor %}
 {% endif %}
-
 
 #------------------
 # listen instances
@@ -168,7 +166,6 @@ frontend {{ frontend[1].get('name', frontend[0]) }}
     {% endif %}
   {%- endfor %}
 {% endif %}
-
 
 #------------------
 # backend instances

--- a/pillar.example
+++ b/pillar.example
@@ -3,6 +3,7 @@
 #
 
 haproxy:
+  enabled: True
   config_file_path: /etc/haproxy/haproxy.cfg
   global:
     stats:


### PR DESCRIPTION
I found the formatting of the haproxy.jinja template file to output lots of unnecessary whitespace, and added debug comments that also didn't begin on a new line. Seemed like a good idea to remove that.

Also, I found the /etc/default/haproxy ENABLED setting doesn't always exist. eg. Debian Wheezy and Jessie (at least) don't have it, and don't honour it even if they do. Hence I switched to using file.replace instead of file.managed. I haven't tested this much, but I believe it should work on Ubuntu or whatever honours ENABLED - if it doesn't already exist (even in commented form), Salt doesn't do anything here now. The haproxy-init-enable and haproxy-init-disable files should now be redundant and can be deleted.

So lastly, I implemented a solution to stop haproxy (and disable the service at startup) via the service state module, if haproxy:enable pillar data is set to False. That seems a more standard and compatible way of managing this to me.

If you deem any of these changes useful enough to pull, you can consider them licensed under the existing Apache License version 2.0. Cheers.