### PR TITLE
adds some default values for essential params

### DIFF
--- a/haproxy/templates/haproxy.jinja
+++ b/haproxy/templates/haproxy.jinja
@@ -31,9 +31,9 @@ global
 # use- if not designated in their block
 #------------------
 defaults
-    log {{ salt['pillar.get']('haproxy:defaults:log') }}
-    mode {{ salt['pillar.get']('haproxy:defaults:mode') }}
-    retries {{ salt['pillar.get']('haproxy:defaults:retries') }}
+    log {{ salt['pillar.get']('haproxy:defaults:log', 'global')}}
+    mode {{ salt['pillar.get']('haproxy:defaults:mode', 'http') }}
+    retries {{ salt['pillar.get']('haproxy:defaults:retries', '3') }}
     balance {{ salt['pillar.get']('haproxy:defaults:balance', 'roundrobin') }}
 {%- if 'options' in salt['pillar.get']('haproxy:defaults', {}) %}
   {%- for option in salt['pillar.get']('haproxy:defaults:options') %}
@@ -44,7 +44,11 @@ defaults
   {%- for timeout in salt['pillar.get']('haproxy:defaults:timeouts') %}
     timeout {{ timeout }}
   {%- endfor %}
-{% endif %}
+{%- else %}
+    timeout client 1m
+    timeout connect 10s
+    timeout server 1m
+{%- endif %}
 {%- if 'errorfiles' in salt['pillar.get']('haproxy:defaults', {}) %}
   {%- for errorfile in salt['pillar.get']('haproxy:defaults:errorfiles').iteritems() %}
     errorfile {{ errorfile[0] }} {{ errorfile[1] }}


### PR DESCRIPTION
With this PR the haproxy.config state will actually render a valid
haproxy.cfg from default values, even when the values are not
explicitly passed via the pillar. Right now, an invalid cfg is
generated which breaks haproxy on startup:
```
[ALERT] 209/101802 (20474) : parsing [/etc/haproxy/haproxy.cfg:25] : 'log' expects either <address[:port]> and <facility> or 'global' as arguments.
[ALERT] 209/101802 (20474) : parsing [/etc/haproxy/haproxy.cfg:26] : unknown proxy mode ''.
[ALERT] 209/101802 (20474) : parsing [/etc/haproxy/haproxy.cfg:27] : 'retries' expects an integer argument (dispatch counts for one).
[ALERT] 209/101802 (20474) : Error(s) found in configuration file : /etc/haproxy/haproxy.cfg
[WARNING] 209/101802 (20474) : config : missing timeouts for frontend 'www-https'.
   | While not properly invalid, you will certainly encounter various problems
   | with such a configuration. To fix this, please ensure that all following
   | timeouts are set to a non-zero value: 'client', 'connect', 'server'.
[WARNING] 209/101802 (20474) : config : missing timeouts for backend 'www-backend'.
   | While not properly invalid, you will certainly encounter various problems
   | with such a configuration. To fix this, please ensure that all following
   | timeouts are set to a non-zero value: 'client', 'connect', 'server'.
[ALERT] 209/101802 (20474) : Fatal errors found in configuration.
```
