### PR TITLE
adds ssl-default-bind options to template

### DIFF
--- a/haproxy/templates/haproxy.jinja
+++ b/haproxy/templates/haproxy.jinja
@@ -24,7 +24,12 @@ global
     # Stats support is currently limited to socket mode
     stats socket {{ salt['pillar.get']('haproxy:global:stats:socketpath', '/tmp/ha_stats.sock') }}
 {%- endif %}
-
+{%- if salt['pillar.get']('haproxy:global:ssl-default-bind-ciphers', False) %}
+    ssl-default-bind-ciphers {{ salt['pillar.get']('haproxy:global:ssl-default-bind-ciphers') }}
+{%- endif %}
+{%- if salt['pillar.get']('haproxy:global:ssl-default-bind-options', False) %}
+    ssl-default-bind-options {{ salt['pillar.get']('haproxy:global:ssl-default-bind-options') }}
+{%- endif %}
 
 #------------------
 # common defaults that all the 'listen' and 'backend' sections will

--- a/pillar.example
+++ b/pillar.example
@@ -9,6 +9,8 @@ haproxy:
     stats:
       enable: True
       socketpath: /var/lib/haproxy/stats
+    ssl-default-bind-ciphers: "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384"
+    ssl-default-bind-options: "no-sslv3 no-tlsv10 no-tlsv11"
 
     user: haproxy
     group: haproxy


### PR DESCRIPTION
This PR introduces two new possible config params that can be set via the pillar: *ssl-default-bind-ciphers* and *ssl-default-bind-options*.

In cases in which the pillar does not include these values, the haproxy.cfg is not changes!

The values in pillar.example are an opt-in option and quite strict. They'll get you an "A" rating on Qualys SSL Labs. However, please make sure that your clients support this subset!