### PR TITLE
Add userlist sample to the example pillar

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -20,6 +20,16 @@ haproxy:
 
     daemon: True
 
+
+  userlists:
+    userlist1:
+      users:
+        john: insecure-password doe
+        sam: insecure-password frodo
+#      groups:
+#        admins: users john sam
+#        guests: users jekyll hyde jane
+
   defaults:
     log: global
     mode: http


### PR DESCRIPTION
Both user-based lists and groups-based lists are included in the example. Groups are prefixed as comments since you usually don't activate both at the same time in haproxy.