### PR TITLE
Correct the redirect examples in pillar.example

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -106,7 +106,8 @@ haproxy:
     frontend1:
       name: www-http
       bind: "*:80"
-      redirect: scheme https if !{ ssl_fc }
+      redirects: 
+        - scheme https if !{ ssl_fc }
       reqadd:
         - "X-Forwarded-Proto:\\ http"
       default_backend: www-backend
@@ -131,7 +132,8 @@ haproxy:
     backend1:
       name: www-backend
       balance: roundrobin
-      redirect: scheme https if !{ ssl_fc }
+      redirects: 
+        - scheme https if !{ ssl_fc }
       servers:
         server1:
           name: server1-its-name
@@ -140,7 +142,8 @@ haproxy:
           check: check
     static-backend:
       balance: roundrobin
-      redirect: scheme https if !{ ssl_fc }
+      redirects: 
+        - scheme https if !{ ssl_fc }
       options:
         - http-server-close
         - httpclose


### PR DESCRIPTION
I found out the redirect directive in the current pillar.example is not working anymore. Proposed changes contain the working variant.