### PR TITLE
Adding new values to global section, typo fix + natural server ordering

### DIFF
--- a/haproxy/templates/haproxy.jinja
+++ b/haproxy/templates/haproxy.jinja
@@ -48,6 +48,15 @@ global
 {%- if 'tune' in salt['pillar.get']('haproxy:global', {}) %}
     {{- render_list_of_dictionaries('tune', salt['pillar.get']('haproxy:global:tune'), '    ','.') }}
 {%- endif %}
+{%- if 'tune.ssl.default-dh-param' in salt['pillar.get']('haproxy:global', {}) %}
+    {{- render_list_of_dictionaries('tune.ssl.default-dh-param', salt['pillar.get']('haproxy:global:tune.ssl.default-dh-param'), '    ','.') }}
+{%- endif %}
+{%- if 'ca-base' in salt['pillar.get']('haproxy:global', {}) %}
+    {{- render_list_of_dictionaries('ca-base', salt['pillar.get']('haproxy:global:ca-base'), '    ','.') }}
+{%- endif %}
+{%- if 'crt-base' in salt['pillar.get']('haproxy:global', {}) %}
+    {{- render_list_of_dictionaries('crt-base', salt['pillar.get']('haproxy:global:crt-base'), '    ','.') }}
+{%- endif %}
 {%- if 'ssl-default-bind-ciphers' in salt['pillar.get']('haproxy:global', {}) %}
     {{- render_list_of_dictionaries('ssl-default-bind-ciphers', salt['pillar.get']('haproxy:global:ssl-default-bind-ciphers')) }}
 {%- endif %}

--- a/haproxy/templates/haproxy.jinja
+++ b/haproxy/templates/haproxy.jinja
@@ -309,7 +309,7 @@ frontend {{ frontend[1].get('name', frontend[0]) }}
     maxconn {{ frontend[1].maxconn }}
     {%- endif %}
     {%- if 'options' in frontend[1] %}
-    {{- render_list_of_dictionaries('options', frontend[1].options) }}
+    {{- render_list_of_dictionaries('option', frontend[1].options) }}
     {%- endif %}
     {%- if 'uniqueidformat' in frontend[1] %}
     unique-id-format {{ frontend[1].uniqueidformat }}

--- a/haproxy/templates/haproxy.jinja
+++ b/haproxy/templates/haproxy.jinja
@@ -283,7 +283,7 @@ listen {{ listener[1].get('name', listener[0]) }}
     default-server {%- for option, value in listener[1].defaultserver.iteritems() %} {{ ' '.join((option, value|string, '')) }} {%- endfor %}
     {%- endif %}
     {%- if 'servers' in listener[1] %}
-      {%- for server in listener[1].servers.iteritems() %}
+      {%- for server in listener[1].servers.iteritems()|sort %}
     server {{ server[1].get('name',server[0]) }} {{ server[1].host }}:{{ server[1].port }} {{ server[1].check }} {{ server[1].get('extra', '') }}
       {%- endfor %}
     {%- endif %}
@@ -457,7 +457,7 @@ backend {{ backend[1].get('name',backend[0]) }}
     default-server {%- for option, value in backend[1].defaultserver.iteritems() %} {{ ' '.join((option, value|string, '')) }} {%- endfor %}
     {%- endif %}
     {%- if 'servers' in backend[1] %}
-      {%- for server in backend[1].servers.iteritems() %}
+      {%- for server in backend[1].servers.iteritems()|sort %}
     server {{ server[1].get('name',server[0]) }} {{ server[1].host }}:{{ server[1].port }} {{ server[1].check }} {{ server[1].get('extra', '') }}
       {%- endfor %}
     {%- endif %}


### PR DESCRIPTION

#### additions to haproxy.jinja -> haproxy.conf global section
tune.ssl.default-dh-param
crt-base
ca-base

#### the option iteration inside the frontend section contained a typo
options -> option

#### added sorting to listen and backend server list
now servers are created in natural order inside haproxy.conf and therefore also show like that in the stats page
