### PR TITLE
Adds support for log-format configuration

### DIFF
--- a/haproxy/templates/haproxy.jinja
+++ b/haproxy/templates/haproxy.jinja
@@ -95,6 +95,9 @@ defaults
 {%- if 'options' in salt['pillar.get']('haproxy:defaults', {}) -%}
     {{- render_list_of_dictionaries('option', salt['pillar.get']('haproxy:defaults:options')) }}
 {%- endif %}
+{%- if 'logformat' in salt['pillar.get']('haproxy:defaults', {}) %}
+    log-format {{ salt['pillar.get']('haproxy:defaults:logformat') }}
+{%- endif %}
 {%- if 'maxconn' in salt['pillar.get']('haproxy:defaults', {}) %}
     maxconn {{ salt['pillar.get']('haproxy:defaults:maxconn') }}
 {%- endif %}
@@ -151,6 +154,9 @@ listen {{ listener[1].get('name', listener[0]) }}
     {%- endif %}
     {%- if 'mode' in listener[1] %}
     mode {{ listener[1].mode }}
+    {%- endif %}
+    {%- if 'logformat' in listener[1] %}
+    log-format {{ listener[1].logformat }}
     {%- endif %}
     {%- if 'uniqueidformat' in listener[1] %}
     unique-id-format {{ listener[1].uniqueidformat }}
@@ -301,6 +307,9 @@ frontend {{ frontend[1].get('name', frontend[0]) }}
     {%- endif %}
     {%- if 'log' in frontend[1] %}
     log {{ frontend[1].log }}
+    {%- endif %}
+    {%- if 'logformat' in frontend[1] %}
+    log-format {{ frontend[1].logformat }}
     {%- endif %}
     {%- if 'mode' in frontend[1] %}
     mode {{ frontend[1].mode }}

--- a/pillar.example
+++ b/pillar.example
@@ -39,6 +39,7 @@ haproxy:
       - dontlognull
       - forwardfor
       - http-server-close
+    logformat: "%ci:%cp\\ [%t]\\ %ft\\ %b/%s\\ %Tq/%Tw/%Tc/%Tr/%Tt\\ %ST\\ %B\\ %CC\\ %CS\\ %tsc\\ %ac/%fc/%bc/%sc/%rc\\ %sq/%bq\\ %hr\\ %hs\\ %{+Q}r"
     timeouts:
       - http-request    10s
       - queue           1m
@@ -114,6 +115,7 @@ haproxy:
 
     www-https:
       bind: "*:443 ssl crt /etc/ssl/private/certificate-chain-and-key-combined.pem"
+      logformat: "%ci:%cp\\ [%t]\\ %ft\\ %b/%s\\ %Tq/%Tw/%Tc/%Tr/%Tt\\ %ST\\ %B\\ %CC\\ %CS\\ %tsc\\ %ac/%fc/%bc/%sc/%rc\\ %sq/%bq\\ %hr\\ %hs\\ %{+Q}r\\ ssl_version:%sslv\\ ssl_cipher:%sslc"
       reqadd:
         - "X-Forwarded-Proto:\\ https"
       default_backend: www-backend


### PR DESCRIPTION
This MR allows you to specify `log-format` configuration as described [here](https://cbonte.github.io/haproxy-dconv/configuration-1.5.html#4.2-log-format).

The main use case why this was implemented is proper logging of ssl versions and ciphers.

I would love to get rid of the double escaping and the inconsistent wording (`logformat` vs `log-format`). But since other options show the same quirks (such as `unique-id-format` ), I think this is currently good enough.