### PR TITLE
Allow usage of haproxy.service without haproxy.config

### DIFF
--- a/haproxy/config.sls
+++ b/haproxy/config.sls
@@ -6,3 +6,5 @@ haproxy.config:
    - user: root
    - group: root
    - mode: 644
+   - watch_in:
+     - service: haproxy.service

--- a/haproxy/service.sls
+++ b/haproxy/service.sls
@@ -7,8 +7,6 @@ haproxy.service:
     - require:
       - pkg: haproxy
         file: haproxy.service
-    - watch:
-      - file: haproxy.config
 {% else %}
   service.dead:
     - name: haproxy


### PR DESCRIPTION
By reversing the requisite.