### PR TITLE
Allow to load sls explicitely

### DIFF
--- a/haproxy/init.sls
+++ b/haproxy/init.sls
@@ -2,12 +2,9 @@
 #
 # Meta-state to fully setup haproxy on debian. (or any other distro that has haproxy in their repo)
 
-include:
 {% if salt['pillar.get']('haproxy:include') %}
-{% for item in salt['pillar.get']('haproxy:include') %}
+include:
+{% for item in salt['pillar.get']('haproxy:include', ('haproxy.install', 'haproxy.service', 'haproxy.config')) %}
   - {{ item }}
 {% endfor %}
 {% endif %}
-  - haproxy.install
-  - haproxy.service
-  - haproxy.config


### PR DESCRIPTION
load only sls we are interested in. By listing them in pillars.

Still defaults on same list for backward compatibility.
