### PR TITLE
/etc/default/haproxy exists only on Debian-based distros

### DIFF
--- a/haproxy/service.sls
+++ b/haproxy/service.sls
@@ -6,12 +6,15 @@ haproxy.service:
     - reload: True
     - require:
       - pkg: haproxy
-        file: haproxy.service
+{% if salt['grains.get']('os_family') == 'Debian' %}
+      - file: haproxy.service
+{% endif %}
 {% else %}
   service.dead:
     - name: haproxy
     - enable: False
 {% endif %}
+{% if salt['grains.get']('os_family') == 'Debian' %}
   file.replace:
     - name: /etc/default/haproxy
 {% if salt['pillar.get']('haproxy:enabled', True) %}
@@ -22,3 +25,4 @@ haproxy.service:
     - repl: ENABLED=0
 {% endif %}
     - show_changes: True
+{% endif %}


### PR DESCRIPTION
Currently it's not possible to do `haproxy.service` on RedHat-based distros (like CentOS). Initscript doesn't use this file at all, so it's not needed to create it anyway.

Actual result:
```----------
          ID: haproxy.service
    Function: file.replace
        Name: /etc/default/haproxy
      Result: False
     Comment: /etc/default/haproxy: file not found
     Started: 16:16:46.775448
    Duration: 2.19 ms
     Changes:
```