### PR TITLE
this is no longer needed - haproxy 1.5.x in ubuntu repo

### DIFF
--- a/haproxy/install.sls
+++ b/haproxy/install.sls
@@ -1,14 +1,3 @@
-# Because on Ubuntu we don't have a current HAProxy in the usual repo, we add a PPA
-{% if salt['grains.get']('osfullname') == 'Ubuntu' %}
-haproxy_ppa_repo:
-  pkgrepo.managed:
-    - ppa: vbernat/haproxy-1.5
-    - require_in:
-      - pkg: haproxy.install
-    - watch_in:
-      - pkg: haproxy.install
-{% endif %}
-
 haproxy.install:
   pkg.installed:
     - name: haproxy


### PR DESCRIPTION
haproxy 1.5.x is available through ubuntu repos now - no need for ppa:

```
root@main:/srv# apt-cache show haproxy|grep Version:
Version: 1.5.4-1ubuntu2.1~ubuntu14.04.1
Version: 1.4.24-2ubuntu0.4
Version: 1.4.24-2
root@main:/srv# 
```