### PR TITLE
Allow omission of 'port' and 'check' from server params

### DIFF
--- a/haproxy/templates/haproxy.jinja
+++ b/haproxy/templates/haproxy.jinja
@@ -308,7 +308,7 @@ listen {{ listener.get('name', listener_name) }}
     {%- endif %}
     {%- if 'servers' in listener %}
       {%- for server_name, server in listener.servers|dictsort %}
-    server {{ server.get('name', server_name) }} {{ server.host }}:{{ server.port }} {{ server.check }} {{ server.get('extra', '') }}
+    server {{ server.get('name', server_name) }} {{ server.host }}{% if 'port' in server %}:{{ server.port }}{% endif %} {{ server.get('check', '') }} {{ server.get('extra', '') }}
       {%- endfor %}
     {%- endif %}
   {% endfor %}
@@ -502,7 +502,7 @@ backend {{ backend.get('name', backend_name) }}
     {%- endif %}
     {%- if 'servers' in backend %}
       {%- for server_name, server in backend.servers|dictsort %}
-    server {{ server.get('name', server_name) }} {{ server.host }}:{{ server.port }} {{ server.check }} {{ server.get('extra', '') }}
+    server {{ server.get('name', server_name) }} {{ server.host }}{% if 'port' in server %}:{{ server.port }}{% endif %} {{ server.get('check', '') }} {{ server.get('extra', '') }}
       {%- endfor %}
     {%- endif %}
   {% endfor %}

--- a/pillar.example
+++ b/pillar.example
@@ -103,6 +103,8 @@ haproxy:
           host: web2.example.com
           port: 18888
           check: check
+        web3:
+          host: web3.example.com
 
   frontends:
     frontend1:
@@ -163,6 +165,8 @@ haproxy:
           host: 123.156.189.111
           port: 8080
           check: check
+        another-server:
+          host: 123.156.189.112
     api-backend:
       options:
         - http-server-close


### PR DESCRIPTION
useful for services that require more than 1 port mapped through (eg passive ftp)

could probably merge this myself, but PR review is better practice?