### PR TITLE
Add missing require to start service after config generation.

### DIFF
--- a/haproxy/config.sls
+++ b/haproxy/config.sls
@@ -6,5 +6,7 @@ haproxy.config:
    - user: root
    - group: root
    - mode: 644
+   - require_in:
+     - service: haproxy.service
    - watch_in:
      - service: haproxy.service


### PR DESCRIPTION
Without require_in service could be started before file generation and fail.