### PR TITLE
Updated group wheel when os_family is FreeBSD.

### DIFF
--- a/haproxy/config.sls
+++ b/haproxy/config.sls
@@ -4,7 +4,11 @@ haproxy.config:
    - source: salt://haproxy/templates/haproxy.jinja
    - template: jinja
    - user: root
+   {% if salt['grains.get']('os_family') == 'FreeBSD' %}
+   - group: wheel
+   {% else %}
    - group: root
+   {% endif %}
    - mode: 644
    - require_in:
      - service: haproxy.service


### PR DESCRIPTION
With this change, haproxy formula works in FreeBSD.