### PR TITLE
Support optional overwrite of existing configuration files

### DIFF
--- a/haproxy/config.sls
+++ b/haproxy/config.sls
@@ -14,3 +14,7 @@ haproxy.config:
      - service: haproxy.service
    - watch_in:
      - service: haproxy.service
+   {% if salt['pillar.get']('haproxy:overwrite', default=True) == False %}
+   - unless:
+     - test -e /etc/haproxy/haproxy.cfg
+   {% endif %}

--- a/haproxy/config.sls
+++ b/haproxy/config.sls
@@ -16,5 +16,5 @@ haproxy.config:
      - service: haproxy.service
    {% if salt['pillar.get']('haproxy:overwrite', default=True) == False %}
    - unless:
-     - test -e /etc/haproxy/haproxy.cfg
+     - test -e {{ salt['pillar.get']('haproxy:config_file_path', '/etc/haproxy/haproxy.cfg') }}
    {% endif %}

--- a/haproxy/templates/haproxy.jinja
+++ b/haproxy/templates/haproxy.jinja
@@ -346,7 +346,7 @@ listen {{ listener.get('name', listener_name) }}
     {%- endif %}
     {%- if 'servers' in listener %}
       {%- for server_name, server in listener.servers|dictsort %}
-    server {{ server.get('name', server_name) }} {{ server.host }}{% if 'port' in server %}:{{ server.port }}{% endif %} {{ server.get('check', '') }} {{ server.get('extra', '') }}
+    server {{ server.get('name', server_name) }} {{ server.host }}{% if 'port' in server %}:{{ server.port }}{% endif %} {% if 'maxconn' in server %} maxconn {{ server.maxconn }}{% endif %} {{ server.get('check', '') }} {{ server.get('extra', '') }}
       {%- endfor %}
     {%- endif %}
   {% endfor %}

--- a/pillar.example
+++ b/pillar.example
@@ -4,6 +4,7 @@
 
 haproxy:
   enabled: True
+  overwrite: True # Overwrite an existing config file if present (default behaviour unless set to false)
   config_file_path: /etc/haproxy/haproxy.cfg
   global:
     stats:


### PR DESCRIPTION
This pull request is more or less identical to the one I made for the NGINX formula.

It's not uncommon to want to use salt to configure an initial boilerplate configuration file and then have some out of bounds program (such as consul-template) configure haproxy using service discovery, etc. This pull requests lets users of the formula prevent the salt state from overwriting the configuration files written by these out of bounds programs.