### PR TITLE
added mode selection for stats socket in global definitions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Currently, only a handful of options can be set using the pillar:
 
 - Global
 
-  + stats: enable stats, curently only via a unix socket which can be set to a path
+  + stats: enable stats, curently only via a unix socket which can be set to a path with custom permissions
   + user: sets the user haproxy shall run as
   + group: sets the group haproxy shall run as
   + chroot: allows you to turn on chroot and set a directory

--- a/haproxy/templates/haproxy.jinja
+++ b/haproxy/templates/haproxy.jinja
@@ -34,7 +34,7 @@ global
     daemon
 {%- endif %}
 {%- if salt['pillar.get']('haproxy:global:stats:enable', 'no') == True %}
-    stats socket {{ salt['pillar.get']('haproxy:global:stats:socketpath', '/tmp/ha_stats.sock') }} level {{ salt['pillar.get']('haproxy:global:stats:level', 'operator') }}
+    stats socket {{ salt['pillar.get']('haproxy:global:stats:socketpath', '/tmp/ha_stats.sock') }} mode {{ salt['pillar.get']('haproxy:global:stats:mode', '660') }} level {{ salt['pillar.get']('haproxy:global:stats:level', 'operator') }}
 {%- endif %}
 {%- if 'maxconn' in salt['pillar.get']('haproxy:global', {}) %}
     maxconn {{ salt['pillar.get']('haproxy:global:maxconn') }}

--- a/pillar.example
+++ b/pillar.example
@@ -10,6 +10,7 @@ haproxy:
     stats:
       enable: True
       socketpath: /var/lib/haproxy/stats
+      mode: 660
       level: admin
     ssl-default-bind-ciphers: "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384"
     ssl-default-bind-options: "no-sslv3 no-tlsv10 no-tlsv11"


### PR DESCRIPTION
there is no 'mode' definition in 'stats socket' which is not secure as by default the socket file is created with 755 permissions. Added a bit of control to socket permissions as well as set 660 permissions by default.