### PR TITLE
haproxy.jinja bugfix: backend.extra array trimming

### DIFF
--- a/haproxy/templates/haproxy.jinja
+++ b/haproxy/templates/haproxy.jinja
@@ -551,7 +551,9 @@ backend {{ backend.get('name', backend_name) }}
       {%- if backend.extra is string %}
     {{ backend.extra }}
       {%- else %}
-    {%- for line in backend.extra %}  {{ line }}  {%- endfor %}
+    {%- for line in backend.extra %}
+    {{ line }}
+    {%- endfor %}
       {%- endif %}
     {%- endif %}
     {%- if 'defaultserver' in backend %}


### PR DESCRIPTION
The whitespace/newline trimming for backend.extra in haproxy.jinja condenses 'extra' (when specified as an array) in a backend to a single line that gets tacked on at the end of whatever line preceded it.

For example:

`backends:`
`  my_backend:`
`    mode: tcp`
`    balance: roundrobin`
`    stickons:`
`      - "whatever you want"`
`    extra:`
`      - "something more"`

results in a line in the config file:
`whatever you want something more`