### PR TITLE
Fix listens "extra"

### DIFF
--- a/haproxy/templates/haproxy.jinja
+++ b/haproxy/templates/haproxy.jinja
@@ -338,7 +338,8 @@ listen {{ listener.get('name', listener_name) }}
       {%- if listener.extra is string %}
     {{ listener.extra }}
       {%- else %}
-    {%- for line in listener.extra %}  {{ line }}  {%- endfor %}
+    {%- for line in listener.extra %}
+    {{ line }}  {%- endfor %}
       {%- endif %}
     {%- endif %}
     {%- if 'defaultserver' in listener %}

--- a/haproxy/templates/haproxy.jinja
+++ b/haproxy/templates/haproxy.jinja
@@ -338,7 +338,7 @@ listen {{ listener.get('name', listener_name) }}
       {%- if listener.extra is string %}
     {{ listener.extra }}
       {%- else %}
-    {%- for line in listerner.extra %}  {{ line }}  {%- endfor %}
+    {%- for line in listener.extra %}  {{ line }}  {%- endfor %}
       {%- endif %}
     {%- endif %}
     {%- if 'defaultserver' in listener %}


### PR DESCRIPTION
This fix prevents the following error if `extra` are used in a `listens`:

```
----------
          ID: haproxy.config
    Function: file.managed
        Name: /etc/haproxy/haproxy.cfg
      Result: False
     Comment: Unable to manage file: Jinja variable 'listerner' is undefined
     Started: 07:32:21.282751
    Duration: 241.105 ms
     Changes:   
----------
```

This fix also ensures line breaks are properly added if the `extra` is a list.