### PR TITLE
Update pillar.example

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -201,5 +201,5 @@ haproxy:
       stickons:
         - "payload_lv(43,1) if clienthello"
       reqrep:
-        - "^([^\ :]*)\ /static/(.*)	\1\ \2"
+        - '^([^\ :]*)\ /static/(.*)	\1\ \2'
       options: "ssl-hello-chk"


### PR DESCRIPTION
not properly escaped line causes error when compiling