### PR TITLE
Add timeouts handling to frontend section of template

### DIFF
--- a/haproxy/templates/haproxy.jinja
+++ b/haproxy/templates/haproxy.jinja
@@ -374,6 +374,11 @@ frontend {{ frontend.get('name', frontend_name) }}
     {%- if 'maxconn' in frontend %}
     maxconn {{ frontend.maxconn }}
     {%- endif %}
+    {%- if 'timeouts' in frontend %}
+      {%- for timeout in frontend.timeouts %}
+    timeout {{ timeout }}
+      {%- endfor %}
+    {%- endif %}
     {%- if 'options' in frontend %}
     {{- render_list_of_dictionaries('option', frontend.options) }}
     {%- endif %}


### PR DESCRIPTION
Had an issue where I wanted to add timeouts to a frontend config block, but discovered it was only in the listen section of the template.
