### PR TITLE
Fix service state when override are used

### DIFF
--- a/haproxy/service.sls
+++ b/haproxy/service.sls
@@ -7,13 +7,13 @@ haproxy.service:
     - enable: True
     - reload: True
     - require:
-      - pkg: haproxy
+      - pkg: haproxy.install
 {% if salt['grains.get']('os_family') == 'Debian' %}
       - file: haproxy.service
 {% endif %}
 {% else %}
   service.dead:
-    - name: haproxy
+    - name: {{ haproxy.service }}
     - enable: False
 {% endif %}
 {% if salt['grains.get']('os_family') == 'Debian' %}


### PR DESCRIPTION
Service.running now uses correct require pkg id if
haproxy.lookup.package is used
Service.dead now uses correct name when haproxy.lookup.service is used