### PR TITLE
Configure config_file for FreeBSD

### DIFF
--- a/haproxy/map.jinja
+++ b/haproxy/map.jinja
@@ -8,6 +8,7 @@
         'service': 'haproxy',
     },
     'FreeBSD': {
+        'config_file': '/usr/local/etc/haproxy.conf',
         'group': 'wheel',
     },
 }, merge=salt['pillar.get']('haproxy:lookup'), base='default') %}


### PR DESCRIPTION
This is needed for generating the right config file for FreeBSD.