### PR TITLE
Added Kitchen tests

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,57 @@
+---
+driver:
+  name: docker
+
+driver_config:
+  use_sudo: false
+  privileged: true
+  provision_command: mkdir -p /run/sshd
+  run_command: /lib/systemd/systemd
+
+platforms:
+  - name: debian-9
+#  - name: ubuntu-18.04
+#  - name: fedora-27
+#  - name: centos-7
+
+provisioner:
+  name: salt_solo
+  log_level: info
+  require_chef: false
+  salt_install: bootstrap
+  salt_version: latest
+  salt_bootstrap_url: https://bootstrap.saltstack.com
+  salt_bootstrap_options: -X -p git -p curl -p sudo
+
+  formula: haproxy
+  dependencies:
+    - name: hosts
+      path: ./test/salt/salt
+
+  pillars_from_files:
+    haproxy.sls: pillar.example
+    hosts.sls: ./test/salt/pillar/hosts.sls
+
+  pillars:
+    top.sls:
+      base:
+        "*":
+          - hosts
+          - haproxy
+
+  state_top:
+    base:
+      '*':
+        - hosts
+        - haproxy
+
+verifier:
+  name: inspec
+  reporter: 
+    - cli
+  inspec_tests:
+    - path: test/integration/default
+
+suites:
+  - name: default
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+sudo: required
+cache: bundler
+language: ruby
+
+services:
+  - docker
+
+before_install:
+  - bundle install
+
+env:
+  matrix:
+    - INSTANCE: default-debian-9
+#    - INSTANCE: default-ubuntu-1804
+#    - INSTANCE: default-fedora-27
+#    - INSTANCE: default-centos-7
+
+script:
+  - bundle exec kitchen verify ${INSTANCE}
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem 'test-kitchen'
+gem 'kitchen-docker'
+gem 'kitchen-salt'
+gem 'kitchen-inspec'
+

--- a/pillar.example
+++ b/pillar.example
@@ -121,23 +121,23 @@ haproxy:
         - "X-Forwarded-Proto:\\ http"
       default_backend: www-backend
 
-    www-https:
-      bind: "*:443 ssl crt /etc/ssl/private/certificate-chain-and-key-combined.pem"
-      logformat: "%ci:%cp\\ [%t]\\ %ft\\ %b/%s\\ %Tq/%Tw/%Tc/%Tr/%Tt\\ %ST\\ %B\\ %CC\\ %CS\\ %tsc\\ %ac/%fc/%bc/%sc/%rc\\ %sq/%bq\\ %hr\\ %hs\\ %{+Q}r\\ ssl_version:%sslv\\ ssl_cipher:%sslc"
-      reqadds:
-        - "X-Forwarded-Proto:\\ https"
-      default_backend: www-backend
-      acls:
-        - url_static       path_beg       -i /static /images /javascript /stylesheets
-        - url_static       path_end       -i .jpg .gif .png .css .js
-      use_backends:
-        - static-backend  if url_static
-      extra: "rspadd  Strict-Transport-Security:\ max-age=15768000"
-    some-services:
-      bind:
-        - "*:8080"
-        - "*:8088"
-      default_backend: api-backend
+#    www-https:
+#      bind: "*:443 ssl crt /etc/ssl/private/certificate-chain-and-key-combined.pem"
+#      logformat: "%ci:%cp\\ [%t]\\ %ft\\ %b/%s\\ %Tq/%Tw/%Tc/%Tr/%Tt\\ %ST\\ %B\\ %CC\\ %CS\\ %tsc\\ %ac/%fc/%bc/%sc/%rc\\ %sq/%bq\\ %hr\\ %hs\\ %{+Q}r\\ ssl_version:%sslv\\ ssl_cipher:%sslc"
+#      reqadds:
+#        - "X-Forwarded-Proto:\\ https"
+#      default_backend: www-backend
+#      acls:
+#        - url_static       path_beg       -i /static /images /javascript /stylesheets
+#        - url_static       path_end       -i .jpg .gif .png .css .js
+#      use_backends:
+#        - static-backend  if url_static
+#      extra: "rspadd  Strict-Transport-Security:\ max-age=15768000"
+#    some-services:
+#      bind:
+#        - "*:8080"
+#        - "*:8088"
+#      default_backend: api-backend
 
   backends:
     backend1:

--- a/test/integration/default/controls/config.rb
+++ b/test/integration/default/controls/config.rb
@@ -1,0 +1,9 @@
+title 'Verify haproxy configuration'
+
+describe file('/etc/haproxy/haproxy.cfg') do
+  it { should be_file }
+  its('owner') { should eq 'root' }
+  its('group') { should eq 'root' }
+  its('mode') { should cmp '0644' }
+end
+

--- a/test/integration/default/controls/package.rb
+++ b/test/integration/default/controls/package.rb
@@ -1,0 +1,6 @@
+title 'Verify haproxy installation'
+
+describe package('haproxy') do
+    it { should be_installed }
+end
+

--- a/test/integration/default/controls/service.rb
+++ b/test/integration/default/controls/service.rb
@@ -1,0 +1,9 @@
+title 'Verify haproxy service'
+
+describe service('haproxy') do
+  it { should be_installed }
+  it { should be_enabled }
+  it { should be_running }
+end
+
+

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,0 +1,6 @@
+name: default
+title: Default Profile
+version: 0.1.0
+supports:
+  - os-name: debian
+

--- a/test/salt/pillar/hosts.sls
+++ b/test/salt/pillar/hosts.sls
@@ -1,0 +1,9 @@
+hosts:
+  - server1: 127.0.0.1
+  - server2: 127.0.0.1
+  - web1.example.com: 127.0.0.1
+  - web2.example.com: 127.0.0.1
+  - web3.example.com: 127.0.0.1
+  - apiserver1.example.com: 127.0.0.1
+  - apiserver2.example.com: 127.0.0.1
+ 

--- a/test/salt/salt/hosts/init.sls
+++ b/test/salt/salt/hosts/init.sls
@@ -1,0 +1,11 @@
+
+{% set hosts = salt['pillar.get']('hosts', []) %}
+
+{% for host in hosts %}
+  {% for name, ip in host.items() %}
+{{ name }}:
+  host.present:
+    - ip: {{ ip }}
+  {% endfor %}
+{% endfor %}
+


### PR DESCRIPTION
Please consider this pull request which adds code to:
  
- enable TravisCI tests
- adds some basic Kitchen/Inspec tests, at the moment only package, some config in file, and service
- pillar.example is used for tests, but TLS directives have been commented out
- tests dedicated states and pillars are added

Please also consider activating TravisCI on this repository.
Thanks.