### PR TITLE
Add log-tag and log-send-hostname

### DIFF
--- a/haproxy/templates/haproxy.jinja
+++ b/haproxy/templates/haproxy.jinja
@@ -31,6 +31,12 @@ global
     log /dev/log    local0
     log /dev/log    local1 notice
 {%- endif %}
+{%- if salt['pillar.get']('haproxy:global:log-tag') %}
+    log-tag {{ salt['pillar.get']('haproxy:global:log-tag', 'haproxy') }}
+{%- endif %}
+{%- if salt['pillar.get']('haproxy:global:log-send-hostname') %}
+    log-send-hostname {{ salt['pillar.get']('haproxy:global:log-send-hostname') }}
+{%- endif %}
     user {{ salt['pillar.get']('haproxy:global:user', 'haproxy') }}
     group {{ salt['pillar.get']('haproxy:global:group', 'haproxy') }}
 {%- if salt['pillar.get']('haproxy:global:chroot:enable', 'no') == True %}

--- a/pillar.example
+++ b/pillar.example
@@ -17,6 +17,10 @@ haproxy:
     log:
       - 127.0.0.1 local2
       - 127.0.0.1 local1 notice
+    # Option log-tag parameter, sets the tag field in the syslog header
+    log-tag: haproxy
+    # Optional log-send-hostname parameter, sets the hostname field in the syslog header
+    log-send-hostname: localhost
     stats:
       enable: True
       socketpath: /var/lib/haproxy/stats


### PR DESCRIPTION
This will add the ability to set the following options in the Global section

* [log-tag](https://cbonte.github.io/haproxy-dconv/1.8/configuration.html#log-tag)
* [log-send-hostname](https://cbonte.github.io/haproxy-dconv/1.8/configuration.html#log-send-hostname)