### PR TITLE
Add support for tcp-checks in listen blocks

### DIFF
--- a/haproxy/templates/haproxy.jinja
+++ b/haproxy/templates/haproxy.jinja
@@ -268,6 +268,15 @@ listen {{ listener.get('name', listener_name) }}
     http-check {{ listener.httpcheck }}
       {%- endif %}
     {%- endif %}
+    {%- if 'tcpchecks' in listener %}
+      {%- if listener.tcpchecks is string %}
+    tcp-check {{ listener.tcpchecks }}
+      {%- else %}
+        {%- for tcpcheck in listener.tcpchecks %}
+    tcp-check {{ tcpcheck }}
+        {%- endfor %}
+      {%- endif %}
+    {%- endif %}
     {%- if 'reqadds' in listener %}
       {%- if listener.reqadds is string %}
     reqadd {{ listener.reqadds }}

--- a/pillar.example
+++ b/pillar.example
@@ -123,7 +123,28 @@ haproxy:
           check: check
         web3:
           host: web3.example.com
-
+    redis:
+      bind:
+        - "*:6379
+      balance: roundrobin
+      defaultserver:
+        fall: 3
+      options:
+        - tcp-check
+      tcpchecks:
+        - send PINGrn
+        - expect string +PONG
+        - send info replicationrn
+        - expect string role:master
+        - send QUITrn
+        - expect string +OK
+      servers:
+        redis1:
+          host: redis1
+          port: 6379
+        redis2:
+          host: redis2
+          port: 6379  
   frontends:
     frontend1:
       name: www-http

--- a/pillar.example
+++ b/pillar.example
@@ -125,7 +125,7 @@ haproxy:
           host: web3.example.com
     redis:
       bind:
-        - "*:6379
+        - '*:6379'
       balance: roundrobin
       defaultserver:
         fall: 3
@@ -139,12 +139,16 @@ haproxy:
         - send QUITrn
         - expect string +OK
       servers:
-        redis1:
-          host: redis1
+        server1:
+          host: server1
           port: 6379
-        redis2:
-          host: redis2
-          port: 6379  
+          check: check
+          extra: port 6379 inter 1s
+        server2:
+          host: server2
+          port: 6379
+          check: check
+          extra: port 6379 inter 1s backup
   frontends:
     frontend1:
       name: www-http


### PR DESCRIPTION
Add tcp-checks support in listeners.
Expected result:
```
backend redis
    balance roundrobin
    option tcp-check
    tcp-check send PINGrn
    tcp-check expect string +PONG
    tcp-check send info replicationrn
    tcp-check expect string role:master
    tcp-check send QUITrn
    tcp-check expect string +OK
    default-server fall 3
    server redis1 redis1:6379
    server redis2 redis2:6379
```