### PR TITLE
feat(peers): support for peering configuration

### DIFF
--- a/haproxy/templates/haproxy.jinja
+++ b/haproxy/templates/haproxy.jinja
@@ -75,6 +75,9 @@ global
 {%- if 'ssl-default-bind-options' in salt['pillar.get']('haproxy:global', {}) %}
     {{- render_list_of_dictionaries('ssl-default-bind-options', salt['pillar.get']('haproxy:global:ssl-default-bind-options')) }}
 {%- endif %}
+{%- if 'localpeer' in salt['pillar.get']('haproxy:global', {}) %}
+    localpeer {{ salt['pillar.get']('haproxy:global:localpeer') }}
+{%- endif %}
 {%- if 'extra' in salt['pillar.get']('haproxy:global', {}) %}
   {%- if salt['pillar.get']('haproxy:global:extra', {}) is string %}
     {{ salt['pillar.get']('haproxy:global:extra') }}
@@ -103,6 +106,36 @@ userlist {{ id }}
   {% endif %}
   {%- endfor %}
 {% endfor %}
+
+{%- for group, peers in salt['pillar.get']('haproxy:peers', {}).items() %}
+peers {{ group }}
+    {%- for peer, data in peers.get('peers', {}).items() %}
+    {%- if data is mapping %}
+    peer {{ peer }}{{ ' ' ~ data.address if 'address' in data else '' }}{{ ':' ~ data.port if 'port' in data else '' }}{{ ' ' ~ data.extra if 'extra' in data else '' }}
+    {%- else %}
+    peer {{ peer }} {{ data }}
+    {%- endif %}
+    {%- endfor %}
+    {%- if 'bind' in peers %}
+    {%- if peers.bind is mapping %}
+    bind {{ peers.bind.address }}:{{ peers.bind.port }}{{ ' ' ~ peers.bind.extra if 'extra' in peers.bind else '' }}
+    {%- else %}
+    bind {{ peers.bind }}
+    {%- endif %}
+    {%- endif %}
+    {%- if 'default-bind' in peers %}
+    default-bind {{ peers['default-bind'] }}
+    {%- endif %}
+    {%- if 'default-server' in peers %}
+    default-server {{ peers['default-server'] }}
+    {%- endif %}
+    {%- for server, data in peers.get('servers', {}).items() %}
+    server {{ server }}{{ ' ' ~ data.address if 'address' in data else '' }}{{ ':' ~ data.port if 'port' in data else '' }}{{ ' ' ~ data.extra if 'extra' in data else '' }}
+    {%- endfor %}
+    {%- if 'shards' in peers %}
+    shards {{ peers.shards }}
+    {%- endif %}
+{%- endfor %}
 
 #------------------
 # common defaults that all the 'listen' and 'backend' sections will

--- a/pillar.example
+++ b/pillar.example
@@ -56,6 +56,35 @@ haproxy:
         john: insecure-password doe
         sam: insecure-password frodo
 
+  peers:
+    mygroup1:
+      peers:
+        myserver1: 2001:db8:100::1:1024
+        # or
+        myserver1:
+          address: 2001:db8:100::1
+          port: 1024
+
+      # HAProxy only allows either the above or the below peer configuration style - but this is not enforced by the formula
+
+      bind: 2001:db8:100::1:1024
+      # or
+      bind:
+        address: 2001:db8:100::1
+        port: 1024
+        extra: ssl crt /etc/ssl/crtkey
+      default-server: ssl verify required ca-file /etc/ssl/ca-bundle.pem
+      servers:
+        myserver1:
+          myserver1: {}
+          myserver2:
+            address: 2001:db8:100::2:1024
+            # or
+            address: 2001:db8:100::2
+            port: 1024
+
+      shards: 3
+
   defaults:
     log: global
     mode: http


### PR DESCRIPTION
Basic support for definition of peering options, using both variants ("peers" and "servers").

<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [x] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [x] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [x] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

Add support for configuring peers.

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->

Reference pillar.example.

### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->



### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [x] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


